### PR TITLE
feat: add Netlify config and fix docs URL format

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,14 @@
+[build]
+  command = "npm run build"
+  publish = "dist"
+
+# Astro generates static files, no SPA redirects needed
+# Let Astro handle 404s naturally
+
+[[headers]]
+  for = "/*"
+  [headers.values]
+    X-Frame-Options = "DENY"
+    X-XSS-Protection = "1; mode=block"
+    X-Content-Type-Options = "nosniff"
+    Referrer-Policy = "strict-origin-when-cross-origin"

--- a/src/pages/docs/index.astro
+++ b/src/pages/docs/index.astro
@@ -6,7 +6,7 @@ import Header from '../../components/Header.astro';
 
 const docs = await getCollection('docs');
 const idMap = new Map(docs.map((d) => [d.id.toLowerCase(), d.id]));
-const hrefFor = (slug: string) => `/docs/${idMap.get(slug.toLowerCase()) ?? slug}/`;
+const hrefFor = (slug: string) => `/docs/${idMap.get(slug.toLowerCase()) ?? slug}`;
 
 const menuStructure = [
 	{


### PR DESCRIPTION
- Added netlify.toml with security headers and build configuration
- Added security headers including X-Frame-Options, XSS Protection, and Content-Type Options
- Fixed documentation URL format by removing trailing slash in hrefFor function
- Set build command to "npm run build" and publish directory to "dist"