### PR TITLE
feat: add Umami analytics tracking script to BaseHead component

### DIFF
--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -114,3 +114,4 @@ const ogType = props.ogType ?? 'website';
 <meta property="twitter:image" content={twitterImageUrl} />
 
 <!-- End Meta Tags -->
+<script defer src="https://analytics.codeevolutionlab.com/script.js" data-website-id="bd06c04e-cf2b-4382-8b44-e37de01201b4"></script>


### PR DESCRIPTION
- Added deferred analytics script with website-id for tracking
- Script loads from analytics.codeevolutionlab.com domain